### PR TITLE
Always fall back to sorting the list by the id, so that duplicate ent…

### DIFF
--- a/ving/record/VingRecord.mjs
+++ b/ving/record/VingRecord.mjs
@@ -855,11 +855,18 @@ export class VingKind {
         where
     ) {
         const sortMethod = (params.sortOrder == 'desc') ? desc : asc;
-        let orderBy = [sortMethod(this.table.createdAt)];
+        let orderBy = [sortMethod(this.table.createdAt), sortMethod(this.table.id)];
         if (params.sortBy) {
             const cols = [];
+            let hasIdSortField = false;
             for (const field of params.sortBy) {
+                if (field == 'id') {
+                    hasIdSortField = true;
+                }
                 cols.push(sortMethod(this.table[field]));
+            }
+            if (!hasIdSortField) {
+                cols.push(sortMethod(this.table.id));
             }
             orderBy = cols;
         }


### PR DESCRIPTION
…ries aren't handled randomly across page boundaries.